### PR TITLE
iphone plus bug fix

### DIFF
--- a/Runtime/Plugins/platform/ios/UIWidgetsViewController.mm
+++ b/Runtime/Plugins/platform/ios/UIWidgetsViewController.mm
@@ -65,6 +65,12 @@
     CGFloat bottom = CGRectGetHeight([[info objectForKey:UIKeyboardFrameEndUserInfoKey] CGRectValue]);
     CGFloat scale = [UIScreen mainScreen].scale;
 
+    // scale == 3 => screen is 1242 * 2208 => we have to perform down-sampling to obtain the real length
+    // 0.8696 = 1920 / 2208, the vertical down-sampling ratio
+    if (scale == 3) {
+        bottom = bottom * 0.8696;
+    }
+
     viewInsets.bottom = bottom * scale;
     padding.bottom = 0;
 


### PR DESCRIPTION
当iPhone为大屏时，它的屏幕大小是1242 * 2208，但实际渲染分辨率为1080 * 1920。为此，iOS的UI框架会自动在渲染时进行downsampling。

但是在Unity中，为了保证渲染效率最优，我们不会真的渲染出1242*2208然后再做downsampling，而是直接在gl这边渲染出1080*1920。因此在Unity内部，我们获得的屏幕大小还是1080*1920，而不是真实的1242*2208。这就导致在我们计算Keyboard高度时，iOS返回给我们的是1242*2208模式下的高度，而我们这边拿到后却根据这个值在1080*1920模式下进行layout，从而出现了较实际值偏大的问题。

目前的fix方法是，直接根据scale=3来判断是否是1242*2208这种机型（包括iphone 6s plus, iphone 6 plus, iphone 7 plus等），然后提前对键盘高度进行类似downsampling的处理。