### PR TITLE
Update readme

### DIFF
--- a/README-ZH.md
+++ b/README-ZH.md
@@ -49,7 +49,7 @@ https://github.com/UnityTech/DocCN 查看。
 ## 使用要求
 
 #### Unity
-安装 Unity 2019.1.14f1 或更高版本。 你可以从[https://unity3d.com/get-unity/download](https://unity3d.com/get-unity/download)下载最新的Unity。
+安装 Unity 2018.4.10f1(LTS) 或 2019.1.14f1 及其更高版本。 你可以从[https://unity3d.com/get-unity/download](https://unity3d.com/get-unity/download)下载最新的Unity。
 
 #### UIWidgets包
 

--- a/README-ZH.md
+++ b/README-ZH.md
@@ -49,7 +49,7 @@ https://github.com/UnityTech/DocCN 查看。
 ## 使用要求
 
 #### Unity
-安装 Unity 2018.4.10f1(LTS) 或 2019.1.14f1 及其更高版本。 你可以从[https://unity3d.com/get-unity/download](https://unity3d.com/get-unity/download)下载最新的Unity。
+安装 **Unity 2018.4.10f1(LTS)** 或 **Unity 2019.1.14f1** 及其更高版本。 你可以从[https://unity3d.com/get-unity/download](https://unity3d.com/get-unity/download)下载最新的Unity。
 
 #### UIWidgets包
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ open-sourced @https://github.com/UnityTech/DocCN.
 ## Requirements
 
 #### Unity
-Install **Unity 2019.1.14f1** or above. You can download the latest Unity on https://unity3d.com/get-unity/download.
+Install **Unity 2018.4.10f1 (LTS)** or **Unity 2019.1.14f1** and above. You can download the latest Unity on https://unity3d.com/get-unity/download.
 
 #### UIWidgets Package
 Visit our Github repository https://github.com/UnityTech/UIWidgets


### PR DESCRIPTION
change the min-compatible Unity version to 2018.4.10f1 and 2019.1.14f1, in which an android 9 safearea bug is fixed