### PR TITLE
Fix aa shapehintbug

### DIFF
--- a/Runtime/ui/renderer/common/geometry/path/path.cs
+++ b/Runtime/ui/renderer/common/geometry/path/path.cs
@@ -78,6 +78,8 @@ namespace Unity.UIWidgets.ui {
             this.needCache = false;
             this.pathKey = 0;
             this._isNaiveRRect = false;
+            this._shapeHint = uiPathShapeHint.Other;
+            this._rRectCorner = 0;
         }
 
         void _reset() {

--- a/Runtime/ui/renderer/common/geometry/path/path.cs
+++ b/Runtime/ui/renderer/common/geometry/path/path.cs
@@ -30,10 +30,8 @@ namespace Unity.UIWidgets.ui {
                 return;
             }
             this._isNaiveRRect = isNaiveRRect && this._hasOnlyMoveTos();
-            if (this._isNaiveRRect) {
-                this._shapeHint = shapeHint;
-                this._rRectCorner = corner;
-            }
+            this._shapeHint = shapeHint;
+            this._rRectCorner = corner;
         }
         
         bool _hasOnlyMoveTos() {


### PR DESCRIPTION
aa shape hint is used to store the description of the shape of a given path. This will help the renderer to skip some costly process for specific shapes (i.e., Rect). 

Since the shape hint is not well maintained, e.g., doesnot clear well when the path is desposed. some bugs are observed. In this PR we fix the issue