### PR TITLE
Change ModalRoute#withName to ModalRoute.withName

### DIFF
--- a/Runtime/widgets/routes.cs
+++ b/Runtime/widgets/routes.cs
@@ -492,7 +492,7 @@ namespace Unity.UIWidgets.widgets {
             }
         }
 
-        public RoutePredicate withName(string name) {
+        public static RoutePredicate withName(string name) {
             return (Route route) => !route.willHandlePopInternally
                                     && route is ModalRoute
                                     && route.settings.name == name;


### PR DESCRIPTION
in Flutter,
`ModalRoute.withName` is a static method.
https://github.com/flutter/flutter/blob/0b8abb4724aa590dd0f429683339b1e045a1594d/packages/flutter/lib/src/widgets/routes.dart#L798

Currently, that of UIWidgets is defined as an instance method.
There may be no reason to make such difference.
So made it static.