### PR TITLE
Fix: Remove TextFormInput maxLines Assertion

### DIFF
--- a/Runtime/material/text_form_field.cs
+++ b/Runtime/material/text_form_field.cs
@@ -90,7 +90,6 @@ namespace UIWidgets.Runtime.material {
             }
         ) {
             D.assert(initialValue == null || controller == null);
-            D.assert(maxLines > 0);
             D.assert(maxLines == null || maxLines > 0);
             D.assert(minLines == null || minLines > 0);
             D.assert((maxLines == null) || (minLines == null) || (maxLines >= minLines),


### PR DESCRIPTION
`TextFormInput#maxLines` can be null.
Setting it null means that infinite lines allowed.
In fact, after removing the assertion, setting it null, building it, and the program will do.

![Mar-04-2020 21-21-08](https://user-images.githubusercontent.com/31783570/75879110-1e821600-5e5e-11ea-8384-df31725cdda4.gif)


FYI: https://api.flutter.dev/flutter/material/TextFormField/TextFormField.html
