### PR TITLE
_handleViewMetricsChanged null pointer exception fixed in iOS.

### DIFF
--- a/Runtime/engine/UIWidgetsPanel.cs
+++ b/Runtime/engine/UIWidgetsPanel.cs
@@ -192,6 +192,13 @@ namespace Unity.UIWidgets.engine {
         }
 
         protected override void OnDisable() {
+            
+            if (this._viewMetricsCallbackRegistered) {
+                this._viewMetricsCallbackRegistered = false;
+                UIWidgetsMessageManager.instance.RemoveChannelMessageDelegate("ViewportMatricsChanged",
+                    this._handleViewMetricsChanged);
+            }
+            
             D.assert(this._windowAdapter != null);
             this._windowAdapter.OnDisable();
             this._windowAdapter = null;


### PR DESCRIPTION
BUG (at least iOS)
1. UIWidgetsPanel is disabled and enabled Unity GUI Text Field.
2. User touches Text Field, Keyboard event comes, ViewportMatricsChanges emited, nullpointer occured in _handleViewMetricsChanged.

FIX: remove handler in onDisable.