### PR TITLE
_handleViewMetricsChanged null pointer exception

### DIFF
--- a/Runtime/engine/UIWidgetsPanel.cs
+++ b/Runtime/engine/UIWidgetsPanel.cs
@@ -192,6 +192,13 @@ namespace Unity.UIWidgets.engine {
         }
 
         protected override void OnDisable() {
+            
+            if (this._viewMetricsCallbackRegistered) {
+                this._viewMetricsCallbackRegistered = false;
+                UIWidgetsMessageManager.instance.RemoveChannelMessageDelegate("ViewportMatricsChanged",
+                    this._handleViewMetricsChanged);
+            }
+            
             D.assert(this._windowAdapter != null);
             this._windowAdapter.OnDisable();
             this._windowAdapter = null;

--- a/Runtime/engine/UIWidgetsPanel.cs
+++ b/Runtime/engine/UIWidgetsPanel.cs
@@ -195,7 +195,7 @@ namespace Unity.UIWidgets.engine {
             
             if (this._viewMetricsCallbackRegistered) {
                 this._viewMetricsCallbackRegistered = false;
-                UIWidgetsMessageManager.instance.RemoveChannelMessageDelegate("ViewportMatricsChanged",
+                UIWidgetsMessageManager.instance?.RemoveChannelMessageDelegate("ViewportMatricsChanged",
                     this._handleViewMetricsChanged);
             }
             

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "com.unity.uiwidgets",
 	"displayName":"UIWidgets",
-	"version": "1.5.4-preview.1",
+	"version": "1.5.4-preview.2",
 	"unity": "2018.4",
 	"description": "UIWidgets allows you to build beautiful cross-platform apps through Unity",
 	"dependencies": {


### PR DESCRIPTION
BUG (at least iOS)

1. UIWidgetsPanel is disabled and enabled Unity GUI Text Field.
2. User touches Text Field, Keyboard event comes, ViewportMatricsChanges emited, nullpointer occured in _handleViewMetricsChanged.

FIX: remove handler in onDisable.